### PR TITLE
Main i18n-pro service enhancements

### DIFF
--- a/projects/i18n-pro-angular/src/lib/services/i18n-pro.service.spec.ts
+++ b/projects/i18n-pro-angular/src/lib/services/i18n-pro.service.spec.ts
@@ -354,4 +354,53 @@ describe('I18nProService', () => {
       service.changeLocale(locale, { localizedDictionary });
     });
   });
+
+  describe('removeLocale', () => {
+    it('should remove an existing locale, but not the active', () => {
+      const enDictionary = { hello: 'Hello'};
+      const itDictionary = { hello: 'Ciao'};
+
+      service.locale$.subscribe((loadedLocale) => {
+        if (loadedLocale == 'en'){
+          service.removeLocale('it');
+          expect(service['_dictionary']).toEqual({'en': enDictionary});
+          expect(service['_dictionary']['it']).toBeUndefined();
+          expect(service['_storedLocales']).not.toContain('it');
+          expect(service.locale$.value).toBe('en');
+        }
+      });
+      service.changeLocale('it', { localizedDictionary: itDictionary });
+      service.changeLocale('en', { localizedDictionary: enDictionary });
+    });
+
+    it('should remove an existing and active locale', () => {
+      const enDictionary = { hello: 'Hello'};
+
+      service.locale$.subscribe((loadedLocale) => {
+        if (loadedLocale == 'en'){
+          service.removeLocale('en');
+          expect(service['_dictionary']).toEqual({});
+          expect(service['_dictionary']['en']).toBeUndefined();
+          expect(service['_storedLocales']).not.toContain('en');
+          expect(service.locale$.value).toBe('');
+        }
+      });
+      service.changeLocale('en', { localizedDictionary: enDictionary });
+    });
+
+    it('should do nothing if locale not exists', () => {
+      const enDictionary = { hello: 'Hello'};
+
+      service.locale$.subscribe((loadedLocale) => {
+        if (loadedLocale == 'en'){
+          service.removeLocale('it');
+          expect(service['_dictionary']).toEqual({ en: enDictionary });
+          expect(service['_dictionary']['it']).toBeUndefined();
+          expect(service['_storedLocales']).not.toContain('it');
+          expect(service.locale$.value).toBe('en');
+        }
+      });
+      service.changeLocale('en', { localizedDictionary: enDictionary });
+    });
+  });
 });

--- a/projects/i18n-pro-angular/src/lib/services/i18n-pro.service.ts
+++ b/projects/i18n-pro-angular/src/lib/services/i18n-pro.service.ts
@@ -139,6 +139,14 @@ export class I18nProService {
     }
   }
 
+  removeLocale(locale: string){
+    delete this._dictionary[locale]
+    this._storedLocales = this._storedLocales.filter(lang => locale !== lang)
+    if(this.locale$.value === locale){
+      this.locale$.next('')
+    }
+  }
+
   t(value: string, ...args: TranslationArguments): string {
     const flatArgs = args.flat();
     const plural = getPluralFromArgs(flatArgs);


### PR DESCRIPTION
### Title
Remove existing locale and localized dictionary

---

### Description

With this pull request has been introduced the possibility to remove a stored locale and its related dictionary. This can be useful if there is the needs to clear or reset the local state of the app.

---

### Changes

- **NPM Package**: Added the method `removeLocale` to remove a stored locale, its related dictionary and optionally reset the active locale.
- **Angular Application**: no changes

---

### Checklist

- [x] Code is linted and formatted.
- [x] Tests added/updated where necessary.
- [ ] Documentation updated (if applicable).
- [ ] Demo app works as expected.

---

### Notes for Reviewers

Is it possible to find more info about usage inside unit test in the file `i18n-pro.service.spec.ts`
